### PR TITLE
Update illuminate/support composer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "illuminate/support": "^11.0",
+    "illuminate/support": "^11.0|^12.0|^13.0",
     "illuminate/console": "^11.0",
     "guzzlehttp/guzzle": "^7.9",
     "symfony/dom-crawler": "^7.0",


### PR DESCRIPTION
Update `illuminate/support` dependency in `composer.json` to support Laravel versions 11, 12, and 13.

---
<a href="https://cursor.com/background-agent?bcId=bc-917ecd11-ef54-422b-b172-26ad3b594888">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-917ecd11-ef54-422b-b172-26ad3b594888">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded compatibility to support Illuminate versions 11.x, 12.x, and 13.x.
  * Improves install/update flexibility for projects on newer Laravel/Illuminate stacks.
  * No user-facing behavior changes or API modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->