### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single PHP/Laravel Composer package (`apogee/laravel-pagespeed-watcher`), not a standalone app. There is no long-running server, frontend, or database process to start for development. Dev work is: install deps, run PHPUnit, run lint, and exercise the Artisan commands via Orchestra Testbench.
+
+Runtime: PHP 8.3 (satisfies `^8.2`) is installed. Composer is available both as the global `composer` command and as the committed PHAR at `bin/composer`. Dependencies live in `vendor/` (not committed); the startup update script runs `composer install`.
+
+### Standard commands (already documented in `composer.json` / `.github/workflows/ci.yml`)
+- Tests: `vendor/bin/phpunit` (or `composer test`). Uses Orchestra Testbench + in-memory SQLite; no external services needed.
+- Validate manifest: `composer validate --strict`.
+- Lint: `composer lint` — note this is best-effort (`|| true`) and runs `vendor/bin/phpcs`, but `squizlabs/php_codesniffer` is NOT a declared dependency, so out of the box it prints "phpcs: not found" and passes. To actually run PSR-12 checks, install phpcs (e.g. `composer global require squizlabs/php_codesniffer`) and run `phpcs --standard=PSR12 src`. The current `src/` has pre-existing PSR-12 violations (trailing whitespace, missing final newlines).
+
+### Running the Artisan commands (no host app in this repo)
+The package ships two Artisan commands, `watcher:test-page` and `watcher:usage`. To run them, use the Testbench console which boots a minimal Laravel app that auto-discovers `WatcherServiceProvider`:
+
+```bash
+export DB_CONNECTION=sqlite DB_DATABASE=/tmp/watcher.sqlite
+export APP_KEY="base64:P5w0pH2K2s0hY4QyY8jL7d6mA9cB3fE0vN5oT2uR1wM="
+touch /tmp/watcher.sqlite
+vendor/bin/testbench migrate:fresh          # creates watcher_* tables
+vendor/bin/testbench watcher:usage
+vendor/bin/testbench watcher:test-page --url=https://example.com
+```
+
+Gotchas:
+- Use a FILE-based SQLite DB (not `:memory:`) when running multiple `testbench` invocations. Each invocation is a separate process, so an in-memory DB is discarded between commands and you'll get "no such table" errors.
+- `watcher:test-page` needs a Google PageSpeed Insights key via `PSI_API_KEY` for a successful run. Keyless requests to the public PSI API are rate-limited (HTTP 429). It is optional — the test suite mocks the PSI HTTP client, so no key is required for `composer test`.
+- Known pre-existing code bug (do not "fix" as part of setup): `WatcherApiUsage::incrementRequests()` uses the SQL function `GREATEST(...)`, which does not exist in SQLite. So any real (non-mocked) PSI request that reaches usage recording fails with `no such function: GREATEST` on SQLite. This does not affect the test suite because tests mock the PSI client and never execute that raw SQL against SQLite.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `apogee/laravel-pagespeed-watcher` Laravel package and documents durable, non-obvious run notes for future Cloud agents.

This PR adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section. No application code was modified.

## Environment

- PHP 8.3 (satisfies `^8.2`) + required extensions (`curl`, `mbstring`, `xml`/`dom`, `sqlite3`, `intl`, `zip`).
- Composer available globally and via committed `bin/composer`.
- Startup update script: `composer install --no-interaction --prefer-dist --no-progress`.

## Verification

| Check | Command | Result |
|-------|---------|--------|
| Manifest | `composer validate --strict` | valid |
| Tests | `vendor/bin/phpunit` | 18 passed, 64 assertions |
| Lint | `phpcs --standard=PSR12 src` | runs (pre-existing PSR-12 violations reported) |
| Run (usage) | `vendor/bin/testbench watcher:usage` | renders report |
| Run (test-page) | `vendor/bin/testbench watcher:test-page` | executes full command + live PSI client path |

Hello-world action: wrote a usage record via the package's `WatcherApiUsage` model, then `watcher:usage` read it back and rendered the report (42 requests / 40 ok / 2 errors, recommendations).

## Notes (documented in AGENTS.md, not fixed here)

- `composer lint` is best-effort (`|| true`) and `squizlabs/php_codesniffer` is not a declared dependency.
- Use a file-based SQLite DB (not `:memory:`) when running multiple `testbench` invocations.
- Pre-existing code bug: `WatcherApiUsage::incrementRequests()` uses SQL `GREATEST()`, unavailable in SQLite, so real (non-mocked) PSI requests fail at usage recording on SQLite. Tests pass because they mock the PSI client.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-491d10b2-8801-45c6-8786-b057af3f46c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-491d10b2-8801-45c6-8786-b057af3f46c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

